### PR TITLE
Implemented SaveNoteInteractor 90%

### DIFF
--- a/src/app/EditNoteUseCaseFactory.java
+++ b/src/app/EditNoteUseCaseFactory.java
@@ -38,12 +38,10 @@ public class EditNoteUseCaseFactory {
         BackMenuController backMenuUseCase = createBackMenuUseCase(editNotePresenter);
         DeleteNoteController deleteNoteUseCase = createDeleteNoteUseCase(editNotePresenter, editNoteDataAccessInterface);
 
-        Note note = editNoteViewModel.getState().getNote();
-
 
         // feel free to add more controllers and view models as necessary
 
-        return new EditNoteView(note, editNoteViewModel, renameUseCase, saveNoteUseCase, backMenuUseCase, deleteNoteUseCase);
+        return new EditNoteView(editNoteViewModel, renameUseCase, saveNoteUseCase, backMenuUseCase, deleteNoteUseCase);
 
     }
 

--- a/src/interface_adapter/edit_note/EditNoteState.java
+++ b/src/interface_adapter/edit_note/EditNoteState.java
@@ -3,11 +3,14 @@ package interface_adapter.edit_note;
 import entity.Note.Note;
 
 public class EditNoteState {
-    private String noteTitle = "";
-    private Note note;
+    private String noteTitle;
+    private String noteText;
+    private String noteID;
 
     public EditNoteState(EditNoteState copy) {
         noteTitle = copy.noteTitle;
+        noteText = copy.noteText;
+        noteID = copy.noteID;
     }
 
     // Because of the previous copy constructor, the default constructor must be explicit.
@@ -16,13 +19,23 @@ public class EditNoteState {
     public String getNoteTitle() {
         return noteTitle;
     }
+    public String getNoteText() {
+        return noteText;
+    }
+
+    public String getNoteID() {
+        return noteID;
+    }
+
     public void setNoteTitle(String noteTitle) {
         this.noteTitle = noteTitle;
     }
-    public Note getNote() {
-        return this.note;
+
+    public void setNoteText(String noteText) {
+        this.noteText = noteText;
     }
-    public void setNote(Note note) {
-        this.note = note;
+
+    public void setNoteID(String noteID) {
+        this.noteID = noteID;
     }
 }

--- a/src/interface_adapter/edit_note/EditNoteState.java
+++ b/src/interface_adapter/edit_note/EditNoteState.java
@@ -13,7 +13,7 @@ public class EditNoteState {
         noteID = copy.noteID;
     }
 
-    // Because of the previous copy constructor, the default constructor must be explicit.
+    // make default constructor explicit bc of copy instructor
     public EditNoteState() {}
 
     public String getNoteTitle() {

--- a/src/interface_adapter/save_note/SaveViewModel.java
+++ b/src/interface_adapter/save_note/SaveViewModel.java
@@ -1,1 +1,0 @@
-//TODO: decide if we need a separate view model for saving the note

--- a/src/view/EditNoteView.java
+++ b/src/view/EditNoteView.java
@@ -72,8 +72,14 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
                     public void actionPerformed(ActionEvent e) {
                         if (e.getSource().equals(saveNote)) {
                             String noteText = noteTextArea.getText();
-                            editViewModel.getState();
-//                            EditNoteView.this.saveNoteController.execute();
+                            EditNoteState editNoteState = editViewModel.getState();
+                            try {
+                                EditNoteView.this.saveNoteController.execute(editNoteState.getNoteTitle(),
+                                                                             editNoteState.getNoteText(),
+                                                                             editNoteState.getNoteID());
+                            } catch (IOException ex) {
+                                throw new RuntimeException(ex);
+                            }
                             System.out.println("clicked save!!");
                         }
                     }

--- a/src/view/EditNoteView.java
+++ b/src/view/EditNoteView.java
@@ -73,6 +73,8 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         if (e.getSource().equals(saveNote)) {
+                            String noteText = noteTextArea.getText();
+                            editViewModel.getState();
 //                            EditNoteView.this.saveNoteController.execute();
                             System.out.println("clicked save!!");
                         }

--- a/src/view/EditNoteView.java
+++ b/src/view/EditNoteView.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 
 public class EditNoteView extends JPanel implements ActionListener, PropertyChangeListener {
     public final String viewName = "editing";
-    private final Note note;
     private final EditNoteViewModel editViewModel;
     private final RenameNoteController renameNoteController;
     private final SaveController saveNoteController;
@@ -30,12 +29,11 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
     private final JTextArea noteTextArea;
     private JButton noteTitleButton;
 
-    public EditNoteView(Note note, EditNoteViewModel editViewModel,
+    public EditNoteView(EditNoteViewModel editViewModel,
                         RenameNoteController renameNoteController,
                         SaveController saveNoteController,
                         BackMenuController backMenuController,
                         DeleteNoteController deleteNoteController) {
-        this.note = note;
         this.editViewModel = editViewModel;
         this.saveNoteController = saveNoteController;
         this.deleteNoteController = deleteNoteController;
@@ -129,7 +127,7 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
                         if (e.getSource().equals(deleteNote)) {
                             System.out.println("Deleted Note");
                             EditNoteState editState = editViewModel.getState();
-                            String noteID = editState.getNote().getId();
+                            String noteID = editState.getNoteID();
                             try {
                                 deleteNoteController.execute(noteID);
                             } catch (IOException ex) {


### PR DESCRIPTION
## Work Summary

- Removed all instances of the `Note` entity from `InterfaceAdapters` as it violated the principles of clean architecture.
- Added `noteID` and `noteTitle` attributes for the `EditNoteState`.
- Implemented 90% of the "Save Note" use case.
  - Remaining functionality: Overriding existing notes on the Sheets API when they have the same `noteID`, rather than creating a new one every time.

## Details

### 1. Removal of `Note` Entity

All occurrences of the `Note` entity have been removed from the `InterfaceAdapters` to adhere to clean architecture principles. This separation ensures a clear and maintainable architectural structure.

### 2. Enhancement of `EditNoteState`

Attributes `noteID` and `noteTitle` have been added to the `EditNoteState` to enrich the state representation, providing necessary information for note editing.

### 3. Progress on "Save Note" Use Case

The implementation of the "Save Note" use case is at 90% completion. The focus has been on persisting notes to the Sheets API. However, a crucial aspect is pending:

#### Remaining Functionality

The final step involves overriding existing notes on the Sheets API when they share the same `noteID`. Currently, a new note is created each time, and the implementation needs to be adjusted to update existing notes intelligently.

## Next Steps

- Finalize the implementation of the "Save Note" use case by addressing the noted functionality gap.
- Conduct thorough testing to ensure the robustness and correctness of the implemented features.

