### PR TITLE
Create Note Bugfix and other new additions/fixes

### DIFF
--- a/src/main/java/app/EditNoteUseCaseFactory.java
+++ b/src/main/java/app/EditNoteUseCaseFactory.java
@@ -53,7 +53,6 @@ public class EditNoteUseCaseFactory {
         RenameNoteController renameUseCase = createRenameUseCase(editNotePresenter, editNoteDataAccessInterface);
 
         SaveController saveNoteUseCase = createSaveUseCase(editNoteDataAccessInterface,
-                                                           (CreateNoteDataAccessInterface) editNoteDataAccessInterface,
                                                            editNotePresenter);
 
         BackMenuController backMenuUseCase = createBackMenuUseCase(editNotePresenter);
@@ -100,13 +99,11 @@ public class EditNoteUseCaseFactory {
 
 
     private static SaveController createSaveUseCase(EditNoteDataAccessInterface editNoteDataAccessInterface,
-                                                    CreateNoteDataAccessInterface createNoteDataAccessInterface,
                                                     EditNoteOutputBoundary editNotePresenter) {
 
         // we need a noteFactory for SaveNoteInteractor, so it can create a note entity when saving new notes.
         NoteFactory noteFactory = new CommonNoteFactory();
-        SaveNoteInteractor saveNoteInteractor = new SaveNoteInteractor(editNoteDataAccessInterface,
-                createNoteDataAccessInterface, noteFactory, editNotePresenter);
+        SaveNoteInteractor saveNoteInteractor = new SaveNoteInteractor(editNoteDataAccessInterface, noteFactory, editNotePresenter);
         return new SaveController(saveNoteInteractor);
     }
 

--- a/src/main/java/app/EditNoteUseCaseFactory.java
+++ b/src/main/java/app/EditNoteUseCaseFactory.java
@@ -62,8 +62,7 @@ public class EditNoteUseCaseFactory {
                                                                         (DeleteNoteDataAccessInterface) editNoteDataAccessInterface);
 
         CreateAISnippetController createAISnippetUseCase = createAISnippetUseCase(editNotePresenter,
-                                                                                  createAISnippetDataAccessInterface,
-                                                                                  editNoteDataAccessInterface);
+                                                                                  createAISnippetDataAccessInterface);
 
         CreateCodeSnippetController createCodeSnippetUseCase = createCodeSnippetUseCase(editNotePresenter,
                                                                                         createCodeSnippetDataAccessInterface);
@@ -112,10 +111,9 @@ public class EditNoteUseCaseFactory {
     }
 
     private static CreateAISnippetController createAISnippetUseCase(EditNoteOutputBoundary editNotePresenter,
-                                                                    CreateAISnippetDataAccessInterface createAISnippetDataAccessObject,
-                                                                    EditNoteDataAccessInterface editNoteDAO) {
+                                                                    CreateAISnippetDataAccessInterface createAISnippetDataAccessObject) {
 
-        CreateAISnippetInputBoundary createAISnippetInteractor = new CreateAISnippetInteractor(createAISnippetDataAccessObject, editNoteDAO, editNotePresenter);
+        CreateAISnippetInputBoundary createAISnippetInteractor = new CreateAISnippetInteractor(createAISnippetDataAccessObject, editNotePresenter);
         return new CreateAISnippetController(createAISnippetInteractor);
     }
 

--- a/src/main/java/data_access/NoteDataAccessObject.java
+++ b/src/main/java/data_access/NoteDataAccessObject.java
@@ -12,26 +12,47 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.*;
 
+// TODO: we currently rely on the root/notes folder already having been created by the user.
+// TODO: make it so that we first check if the folder exists and if it does not, the code creates one
+// TODO: this way our program will not rely on users having properly instantiated the folders by themselves
+// TODO: if u guys (zoro) dont have time, then ill just do it myself (dandelion)
+
 public class NoteDataAccessObject implements CreateNoteDataAccessInterface,
         EditNoteDataAccessInterface, DeleteNoteDataAccessInterface, SearchNotesAccessInterface {
 
     private static final Map<Note, File> allNotes = new HashMap<>();
-    private static int noteNumber = 0;
     private static Note currentNote;
+    private int tempNoteCount; // delete this after implementing getNoteCount() and incrementNoteCount()
 
     @Override
     public void create(Note note) throws IOException {
+        tempNoteCount++;
+//        this.incrementNoteCount(); // implement this!!
 
         // setting the ID of note most recently accessed
-        noteNumber = note.getID();
+        int noteNumber = note.getID();
 
-        File noteFile = new File("notes/note"+noteNumber+".csv");
+        File noteFile = new File("notes/note"+ noteNumber +".csv");
 
         // updating variables so we can more easily edit the note
         currentNote = note;
         allNotes.put(note, noteFile);
 
-        this.updateNote(note.getID(), "", note.getName());
+        this.updateNote(note.getID(), note.getText(), note.getName());
+    }
+
+    @Override
+    public int getNoteCount() {
+        // TODO: create a file in notes, notes/data.csv, which holds the number of notes created as an integer value
+        // TODO: the data.csv file will only contain 1 integer entry, representing the NoteCount
+        // TODO: if the file does not exist (it wont for first time), create it and set the integer value to 0, then return this 0 value
+        // TODO: if the file already exists, read the value from it and return it
+        return tempNoteCount; // temporary attribute value for one-run testing. we lose this value after stopping program; hence the entire reason we must add a data.csv file for persistence
+    }
+
+    @Override
+    public void incrementNoteCount() {
+        // TODO: see above todos. call getNoteCount() and add 1 to it then write the incremented value to the data.csv
     }
 
     @Override

--- a/src/main/java/entity/Note/CommonNoteFactory.java
+++ b/src/main/java/entity/Note/CommonNoteFactory.java
@@ -5,11 +5,8 @@ import java.util.List;
 
 public class CommonNoteFactory implements NoteFactory{
 
-    private static int noteID = -1;
-
     @Override
-    public Note create(String name, String text) {
-        noteID += 1;
+    public Note create(String name, String text, int noteID) {
         System.out.println(noteID);
         return new CommonNote(name, text, noteID);
     }

--- a/src/main/java/entity/Note/NoteFactory.java
+++ b/src/main/java/entity/Note/NoteFactory.java
@@ -5,6 +5,6 @@ import java.util.List;
 
 public interface NoteFactory {
 
-    Note create(String name, String text);
+    Note create(String name, String text, int NoteID);
 
 }

--- a/src/main/java/interface_adapter/create_AI_snippet/CreateAISnippetController.java
+++ b/src/main/java/interface_adapter/create_AI_snippet/CreateAISnippetController.java
@@ -2,6 +2,7 @@ package interface_adapter.create_AI_snippet;
 
 import interface_adapter.edit_note.EditNoteState;
 import use_case.create_AI_snippet.CreateAISnippetInputBoundary;
+import use_case.create_AI_snippet.CreateAISnippetInputData;
 import use_case.save_note.SaveNoteInputData;
 
 import java.io.IOException;
@@ -14,7 +15,8 @@ public class CreateAISnippetController {
         this.createAISnippetInteractor = createAISnippetInteractor;
     }
 
-    public void execute(String prompt, String noteText, EditNoteState editNoteState) throws IOException {
-        this.createAISnippetInteractor.execute(prompt, noteText, editNoteState);
+    public void execute(String prompt, String noteText, String noteTitle, int noteID) throws IOException {
+        CreateAISnippetInputData createAISnippetInputData = new CreateAISnippetInputData(prompt, noteText, noteTitle, noteID);
+        this.createAISnippetInteractor.execute(createAISnippetInputData);
     }
 }

--- a/src/main/java/interface_adapter/create_code_snippet/CreateCodeSnippetController.java
+++ b/src/main/java/interface_adapter/create_code_snippet/CreateCodeSnippetController.java
@@ -14,8 +14,8 @@ public class CreateCodeSnippetController {
         this.createCodeSnippetInteractor = createCodeSnippetInteractor;
     }
 
-    public void execute(String code, String text, EditNoteState editNoteState) throws IOException {
-        CreateCodeSnippetInputData createCodeSnippetInputData = new CreateCodeSnippetInputData(code, text, editNoteState);
+    public void execute(String code, String noteText, String noteTitle, int noteID) throws IOException {
+        CreateCodeSnippetInputData createCodeSnippetInputData = new CreateCodeSnippetInputData(code, noteText, noteTitle, noteID);
         this.createCodeSnippetInteractor.execute(createCodeSnippetInputData);
     }
 }

--- a/src/main/java/interface_adapter/create_note/CreateNoteController.java
+++ b/src/main/java/interface_adapter/create_note/CreateNoteController.java
@@ -1,8 +1,6 @@
 package interface_adapter.create_note;
-import entity.Note.Note;
 import use_case.create_note.CreateNoteInputBoundary;
 import use_case.create_note.CreateNoteInputData;
-import use_case.create_note.CreateNoteInteractor;
 
 import java.io.IOException;
 
@@ -13,8 +11,8 @@ public class CreateNoteController{
         this.createNoteInteractor = createNoteInteractor;
     }
 
-    public void execute(String name) throws IOException {
-        CreateNoteInputData createNoteInputData = new CreateNoteInputData(name);
+    public void execute(String noteTitle, String noteText) throws IOException {
+        CreateNoteInputData createNoteInputData = new CreateNoteInputData(noteTitle, noteText);
         this.createNoteInteractor.execute(createNoteInputData);
     }
 }

--- a/src/main/java/interface_adapter/edit_note/EditNotePresenter.java
+++ b/src/main/java/interface_adapter/edit_note/EditNotePresenter.java
@@ -27,8 +27,9 @@ public class EditNotePresenter implements EditNoteOutputBoundary {
     @Override
     public void prepareNote(EditNoteOutputData note) {
         EditNoteState noteState = editNoteViewModel.getState();
-        noteState.setNoteTitle(note.getTitle());
-        noteState.setNoteText(note.getText());
+        noteState.setNoteTitle(note.getNoteTitle());
+        noteState.setNoteText(note.getNoteText());
+        noteState.setNoteID(note.getNoteID()); // be careful that createNote is the only one that affects this
         this.editNoteViewModel.setState(noteState);
         this.editNoteViewModel.firePropertyChanged();
 

--- a/src/main/java/use_case/create_AI_snippet/CreateAISnippetInputBoundary.java
+++ b/src/main/java/use_case/create_AI_snippet/CreateAISnippetInputBoundary.java
@@ -7,6 +7,6 @@ import java.io.IOException;
 
 public interface CreateAISnippetInputBoundary {
 
-    void execute(String prompt, String noteText, EditNoteState editNoteState) throws IOException;
+    void execute(CreateAISnippetInputData createAISnippetInputData) throws IOException;
 
 }

--- a/src/main/java/use_case/create_AI_snippet/CreateAISnippetInputData.java
+++ b/src/main/java/use_case/create_AI_snippet/CreateAISnippetInputData.java
@@ -1,4 +1,30 @@
 package use_case.create_AI_snippet;
 
 public class CreateAISnippetInputData {
+    private final String prompt;
+    private final String noteText;
+    private final String noteTitle;
+    private final int noteID;
+    public CreateAISnippetInputData(String prompt, String noteText, String noteTitle, int noteID) {
+        this.prompt = prompt;
+        this.noteText = noteText;
+        this.noteTitle = noteTitle;
+        this.noteID = noteID;
+    }
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    public String getNoteText() {
+        return noteText;
+    }
+
+    public String getNoteTitle() {
+        return noteTitle;
+    }
+
+    public int getNoteID() {
+        return noteID;
+    }
 }

--- a/src/main/java/use_case/create_AI_snippet/CreateAISnippetInteractor.java
+++ b/src/main/java/use_case/create_AI_snippet/CreateAISnippetInteractor.java
@@ -1,8 +1,5 @@
 package use_case.create_AI_snippet;
 
-import interface_adapter.edit_note.EditNotePresenter;
-import interface_adapter.edit_note.EditNoteState;
-import use_case.edit_note.EditNoteDataAccessInterface;
 import use_case.edit_note.EditNoteOutputBoundary;
 import use_case.edit_note.EditNoteOutputData;
 

--- a/src/main/java/use_case/create_AI_snippet/CreateAISnippetInteractor.java
+++ b/src/main/java/use_case/create_AI_snippet/CreateAISnippetInteractor.java
@@ -10,31 +10,34 @@ import java.io.IOException;
 
 public class CreateAISnippetInteractor implements CreateAISnippetInputBoundary{
     private final CreateAISnippetDataAccessInterface createAISnippetDataAccessObject;
-    private final EditNoteDataAccessInterface editNoteDAO;
+
     private final EditNoteOutputBoundary editNotePresenter;
 
-    public CreateAISnippetInteractor(CreateAISnippetDataAccessInterface createAISnippetDataAccessObject, EditNoteDataAccessInterface editNoteDAO, EditNoteOutputBoundary editNotePresenter) {
+    public CreateAISnippetInteractor(CreateAISnippetDataAccessInterface createAISnippetDataAccessObject,
+                                     EditNoteOutputBoundary editNotePresenter) {
         this.createAISnippetDataAccessObject = createAISnippetDataAccessObject;
-        this.editNoteDAO = editNoteDAO;
         this.editNotePresenter = editNotePresenter;
     }
 
     @Override
-    public void execute(String prompt, String noteText, EditNoteState editNoteState) throws IOException {
+    public void execute(CreateAISnippetInputData createAISnippetInputData) throws IOException {
+        // unpack data
+        String prompt = createAISnippetInputData.getPrompt();
+        String currentText = createAISnippetInputData.getNoteText();
+        String noteTitle = createAISnippetInputData.getNoteTitle();
+        int noteID = createAISnippetInputData.getNoteID();
+
         // Use the DAO to use the API to give us back the AI response
         StringBuilder response = createAISnippetDataAccessObject.getResponse(prompt);
 
         // Convert the response to a string
         String aiResponse = new String(response);
 
-        // Concatenate the AI response to the existing note text with proper formatting
-        String text = noteText + "\nAI Snippet Output:\n" + aiResponse;
-
-        // Update the note using the DAO
-        editNoteDAO.updateNote(editNoteState.getNoteID(), text, editNoteState.getNoteTitle());
+        // Concatenate the AI response to the existing note noteText with proper formatting
+        String noteText = currentText + "\nAI Snippet Output:\n" + aiResponse;
 
         // Prepare the output data and notify the presenter
-        EditNoteOutputData editNoteOutputData = new EditNoteOutputData(editNoteState.getNoteID(), editNoteState.getNoteTitle(), text);
+        EditNoteOutputData editNoteOutputData = new EditNoteOutputData(noteID, noteTitle, noteText);
         editNotePresenter.prepareNote(editNoteOutputData);
     }
 }

--- a/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInputData.java
+++ b/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInputData.java
@@ -5,24 +5,30 @@ import use_case.create_note.CreateNoteInputData;
 
 public class CreateCodeSnippetInputData {
     final private String code;
-    final private String text;
-    final private EditNoteState editNoteState;
+    final private String noteText;
+    final private String noteTitle;
+    final private int noteID;
 
-    public CreateCodeSnippetInputData(String code, String text, EditNoteState editNoteState) {
+    public CreateCodeSnippetInputData(String code, String noteText, String noteTitle, int noteID) {
         this.code = code;
-        this.text = text;
-        this.editNoteState = editNoteState;
+        this.noteText = noteText;
+        this.noteTitle = noteTitle;
+        this.noteID = noteID;
     }
 
     public String getCode() {
         return code;
     }
 
-    public String getText() {
-        return text;
+    public String getNoteText() {
+        return noteText;
     }
 
-    public EditNoteState getNoteState() {
-        return editNoteState;
+    public String getNoteTitle() {
+        return noteTitle;
+    }
+
+    public int getNoteID() {
+        return noteID;
     }
 }

--- a/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInteractor.java
+++ b/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInteractor.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 public class CreateCodeSnippetInteractor implements CreateCodeSnippetInputBoundary {
     private final CreateCodeSnippetDataAccessInterface createCodeSnippetDataAccessObject;
     private final EditNoteOutputBoundary editNotePresenter;
-    private final String dashes = "\n---\n";
 
     public CreateCodeSnippetInteractor(CreateCodeSnippetDataAccessInterface createCodeSnippetDataAccessObject,
                                        EditNoteOutputBoundary editNotePresenter) {
@@ -44,6 +43,7 @@ public class CreateCodeSnippetInteractor implements CreateCodeSnippetInputBounda
             }
         }
 
+        String dashes = "\n---\n";
         newText = currentText + newText + "Ran code snippet:" + dashes + code + dashes + codeReturn;
 
         // prepare the output data and notify the presenter

--- a/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInteractor.java
+++ b/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInteractor.java
@@ -21,34 +21,36 @@ public class CreateCodeSnippetInteractor implements CreateCodeSnippetInputBounda
     @Override
     public void execute(CreateCodeSnippetInputData createCodeSnippetInputData) throws IOException {
 
-        EditNoteState editNoteState = createCodeSnippetInputData.getNoteState();
         String code = createCodeSnippetInputData.getCode();
-        String text = createCodeSnippetInputData.getText();
+        String currentText = createCodeSnippetInputData.getNoteText();
         // use the DAO to execute the code and get the response
         StringBuilder output = createCodeSnippetDataAccessObject.executeCode(code);
 
-        // update current text with new text. note we do NOT retrieve the current text from our editNoteDAO, we get it from note state
+        // update current currentText with new currentText. note we do NOT retrieve the current currentText from our editNoteDAO, we get it from note state
         String codeReturn = new String(output);
         System.out.println(codeReturn);
 
         // set appropriate amount of newline characters
         String newText = "\n\n";
-        int l = text.length();
-        if (text.isEmpty()) {
+        int l = currentText.length();
+        if (currentText.isEmpty()) {
             newText = "";
-        } else if (text.charAt(l - 1) == '\n') {
+        } else if (currentText.charAt(l - 1) == '\n') {
             System.out.println("bababooey");
             newText = "\n";
         } if (l > 2) {
-            if (text.charAt(l - 1) == '\n' && text.charAt(l - 2) == '\n') {
+            if (currentText.charAt(l - 1) == '\n' && currentText.charAt(l - 2) == '\n') {
                 newText = "";
             }
         }
 
-        newText = text + newText + "Ran code snippet:" + dashes + code + dashes + codeReturn;
+        newText = currentText + newText + "Ran code snippet:" + dashes + code + dashes + codeReturn;
 
         // prepare the output data and notify the presenter
-        EditNoteOutputData editNoteOutputData = new EditNoteOutputData(editNoteState.getNoteID(), editNoteState.getNoteTitle(), newText);
+        EditNoteOutputData editNoteOutputData = new EditNoteOutputData(
+                createCodeSnippetInputData.getNoteID(),
+                createCodeSnippetInputData.getNoteTitle(),
+                newText);
         editNotePresenter.prepareNote(editNoteOutputData);
     }
 }

--- a/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInteractor.java
+++ b/src/main/java/use_case/create_code_snippet/CreateCodeSnippetInteractor.java
@@ -1,7 +1,5 @@
 package use_case.create_code_snippet;
 
-import interface_adapter.edit_note.EditNoteState;
-import use_case.edit_note.EditNoteDataAccessInterface;
 import use_case.edit_note.EditNoteOutputBoundary;
 import use_case.edit_note.EditNoteOutputData;
 

--- a/src/main/java/use_case/create_note/CreateNoteDataAccessInterface.java
+++ b/src/main/java/use_case/create_note/CreateNoteDataAccessInterface.java
@@ -8,4 +8,5 @@ public interface CreateNoteDataAccessInterface {
 
     void create(Note note) throws IOException;
 
+    int getNoteCount();
 }

--- a/src/main/java/use_case/create_note/CreateNoteInputData.java
+++ b/src/main/java/use_case/create_note/CreateNoteInputData.java
@@ -1,13 +1,19 @@
 package use_case.create_note;
 
 public class CreateNoteInputData {
-    String noteTitle;
+    private final String noteTitle;
+    private final String noteText;
 
-    public CreateNoteInputData(String noteTitle) {
+    public CreateNoteInputData(String noteTitle, String noteText) {
         this.noteTitle = noteTitle;
+        this.noteText = noteText;
     }
 
     public String getNoteTitle() {
-        return this.noteTitle;
+        return noteTitle;
+    }
+
+    public String getNoteText() {
+        return noteText;
     }
 }

--- a/src/main/java/use_case/create_note/CreateNoteInteractor.java
+++ b/src/main/java/use_case/create_note/CreateNoteInteractor.java
@@ -2,6 +2,7 @@ package use_case.create_note;
 
 import entity.Note.Note;
 import entity.Note.NoteFactory;
+import interface_adapter.edit_note.EditNoteState;
 import use_case.edit_note.EditNoteOutputBoundary;
 import use_case.edit_note.EditNoteOutputData;
 
@@ -29,12 +30,13 @@ public class CreateNoteInteractor implements CreateNoteInputBoundary {
         //2. using our DAO to do any persistence
         //3. preparing success view or fail view
 
-        String noteText = "";
-        String noteTitle = createNoteInputData.getNoteTitle();
-        Note note = noteFactory.create(noteTitle, noteText);
-        noteDataAccessObject.create(note);
+        // get the appropriate noteID to set and set it on the state (not DAO)
+        int noteID = noteDataAccessObject.getNoteCount() + 1;
 
-        EditNoteOutputData editNoteOutputData = new EditNoteOutputData(note.getID(), note.getName(), note.getText());
+        String noteText = createNoteInputData.getNoteText();
+        String noteTitle = createNoteInputData.getNoteTitle();
+
+        EditNoteOutputData editNoteOutputData = new EditNoteOutputData(noteID, noteTitle, noteText);
         editNotePresenter.prepareNote(editNoteOutputData);
     }
 }

--- a/src/main/java/use_case/edit_note/EditNoteDataAccessInterface.java
+++ b/src/main/java/use_case/edit_note/EditNoteDataAccessInterface.java
@@ -17,4 +17,6 @@ public interface EditNoteDataAccessInterface {
   
     void setCurrentText(String text);
 
+    int getNoteCount();
+    void incrementNoteCount();
 }

--- a/src/main/java/use_case/edit_note/EditNoteOutputData.java
+++ b/src/main/java/use_case/edit_note/EditNoteOutputData.java
@@ -1,29 +1,26 @@
 package use_case.edit_note;
 
-import entity.Note.Note;
-
-import java.util.List;
-
 public class EditNoteOutputData {
 
-    private int noteId;
-    private String title;
-    private String text;
+    private String noteTitle;
+    private String noteText;
+    private int noteID;
 
-    public EditNoteOutputData(int Id, String title, String text) {
-        this.noteId = Id;
-        this.title = title;
-        this.text = text;
+    public EditNoteOutputData(int noteID, String noteTitle, String noteText) {
+        this.noteTitle = noteTitle;
+        this.noteText = noteText;
+        this.noteID = noteID;
     }
 
-    public String getTitle() {
-        return this.title;
+    public String getNoteTitle() {
+        return noteTitle;
     }
 
-    public String getText() {return this.text;}
-
-    public int getID() {
-        return this.noteId;
+    public String getNoteText() {
+        return noteText;
     }
 
+    public int getNoteID() {
+        return noteID;
+    }
 }

--- a/src/main/java/use_case/save_note/SaveNoteInteractor.java
+++ b/src/main/java/use_case/save_note/SaveNoteInteractor.java
@@ -2,8 +2,6 @@ package use_case.save_note;
 
 import entity.Note.Note;
 import entity.Note.NoteFactory;
-import interface_adapter.edit_note.EditNotePresenter;
-import interface_adapter.edit_note.EditNoteState;
 import use_case.create_note.CreateNoteDataAccessInterface;
 import use_case.edit_note.EditNoteDataAccessInterface;
 import use_case.edit_note.EditNoteOutputBoundary;
@@ -13,37 +11,37 @@ import java.io.IOException;
 
 public class SaveNoteInteractor implements SaveNoteInputBoundary{
 
-    private final EditNoteDataAccessInterface editNoteDataAccessInterface;
-    private final CreateNoteDataAccessInterface createNoteDataAccessInterface;
+    private final EditNoteDataAccessInterface noteDataAccessObject;
     private final NoteFactory noteFactory;
     private final EditNoteOutputBoundary editNotePresenter;
 
-    public SaveNoteInteractor(EditNoteDataAccessInterface editNoteDataAccessInterface,
-                              CreateNoteDataAccessInterface createNoteDataAccessInterface,
+    public SaveNoteInteractor(EditNoteDataAccessInterface noteDataAccessObject,
                               NoteFactory noteFactory,
                               EditNoteOutputBoundary editNotePresenter) {
-        this.editNoteDataAccessInterface = editNoteDataAccessInterface;
-        this.createNoteDataAccessInterface = createNoteDataAccessInterface;
+        this.noteDataAccessObject = noteDataAccessObject;
         this.noteFactory = noteFactory;
         this.editNotePresenter = editNotePresenter;
     }
 
     @Override
     public void execute(SaveNoteInputData saveNoteInputData) throws IOException {
-        // create a note entity using the InputData
         int noteID = saveNoteInputData.getNoteID();
+        // create a note entity using the InputData
         String noteText = saveNoteInputData.getNoteText();
         String noteTitle = saveNoteInputData.getNoteTitle();
 
-        if (editNoteDataAccessInterface.existsByID(noteID)) { // note already exists
+        if (noteDataAccessObject.existsByID(noteID)) { // note already exists
             System.out.println("Note exists.");
 
-            editNoteDataAccessInterface.updateNote(noteID, noteText, noteTitle);
-            System.out.println(editNoteDataAccessInterface.getCurrentText());
+            noteDataAccessObject.updateNote(noteID, noteText, noteTitle);
+            System.out.println(noteDataAccessObject.getCurrentText());
 
             EditNoteOutputData editNoteOutputData = new EditNoteOutputData(noteID, noteTitle, noteText);
             editNotePresenter.prepareNote(editNoteOutputData);
 
+        } else {
+            Note note = noteFactory.create(noteTitle, noteText, noteID);
+            ((CreateNoteDataAccessInterface) noteDataAccessObject).create(note);
         }
     }
 }

--- a/src/main/java/use_case/save_note/SaveNoteInteractor.java
+++ b/src/main/java/use_case/save_note/SaveNoteInteractor.java
@@ -26,7 +26,8 @@ public class SaveNoteInteractor implements SaveNoteInputBoundary{
     @Override
     public void execute(SaveNoteInputData saveNoteInputData) throws IOException {
         int noteID = saveNoteInputData.getNoteID();
-        // create a note entity using the InputData
+
+        // create a note entity using the InputData if note does not exist
         String noteText = saveNoteInputData.getNoteText();
         String noteTitle = saveNoteInputData.getNoteTitle();
 

--- a/src/main/java/use_case/search_notes/SearchInteractor.java
+++ b/src/main/java/use_case/search_notes/SearchInteractor.java
@@ -1,10 +1,8 @@
 package use_case.search_notes;
 
 import entity.Note.Note;
-import interface_adapter.edit_note.EditNotePresenter;
 import use_case.edit_note.EditNoteOutputBoundary;
 import use_case.edit_note.EditNoteOutputData;
-import java.util.List;
 
 import java.io.IOException;
 
@@ -24,8 +22,7 @@ public class SearchInteractor implements SearchInputBoundary{
         Note note = this.searchNotesAccessInterface.findByTitle(search);
 
         if(note != null) {
-            EditNoteOutputData editNoteOutputData = new EditNoteOutputData(note.getID(),
-                    note.getName(), note.getText());
+            EditNoteOutputData editNoteOutputData = new EditNoteOutputData(note.getID(), note.getName(), note.getText());
             editNotePresenter.prepareNote(editNoteOutputData);
         }
 

--- a/src/main/java/view/EditNoteView.java
+++ b/src/main/java/view/EditNoteView.java
@@ -14,6 +14,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
@@ -82,6 +84,7 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
 
         // TODO: Add a general keyTyped event to the noteTextArea which always updates noteState in live
         // TODO: this way we wont need to call noteTextArea.getText() every time, we just take from the NoteState
+
 
         // ===== SAVE NOTE LISTENER =====
         saveNote.addActionListener(
@@ -159,10 +162,13 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
 
                         if (result == JOptionPane.OK_OPTION) {
                             String code = codeArea.getText();
-                            String noteText = noteTextArea.getText();
                             EditNoteState editNoteState = editViewModel.getState();
                             try {
-                                createCodeSnippetController.execute(code, noteText, editNoteState);
+                                createCodeSnippetController.execute(
+                                        code,
+                                        editNoteState.getNoteText(),
+                                        editNoteState.getNoteTitle(),
+                                        editNoteState.getNoteID());
                             } catch (IOException ex) {
                                 throw new RuntimeException(ex);
                             }
@@ -180,12 +186,14 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
                     public void actionPerformed(ActionEvent e) {
                         if (e.getSource().equals(noteTitleButton)) {
                             String newTitle = JOptionPane.showInputDialog("Enter a new title");
-                            String noteText = noteTextArea.getText();
                             EditNoteState editNoteState = editViewModel.getState();
                             if (newTitle != null) {
                                 try {
-                                    renameNoteController.execute(editNoteState.getNoteID(),
-                                            newTitle, noteText);
+                                    renameNoteController.execute(
+                                            editNoteState.getNoteID(),
+                                            newTitle,
+                                            editNoteState.getNoteText());
+
                                 } catch (IOException ex) {
                                     throw new RuntimeException(ex);
                                 }
@@ -234,6 +242,27 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
         // Add the buttons JPanel to the south of this JPanel
         this.add(buttons, BorderLayout.SOUTH);
         add(noteTitleButton, BorderLayout.NORTH);// add the title button to the north of this JPanel
+
+        // ===== KEY PRESS LISTENER =====
+        noteTextArea.addKeyListener(
+                new KeyListener() {
+                    @Override
+                    public void keyTyped(KeyEvent e) {
+                        EditNoteState currentState = editViewModel.getState();
+                        String text = noteTextArea.getText() + e.getKeyChar();
+                        currentState.setNoteText(text);
+                        editViewModel.setState(currentState);
+                    }
+
+                    @Override
+                    public void keyPressed(KeyEvent e) {
+                    }
+
+                    @Override
+                    public void keyReleased(KeyEvent e) {
+                    }
+                });
+        // ==============================
     }
 
 

--- a/src/main/java/view/EditNoteView.java
+++ b/src/main/java/view/EditNoteView.java
@@ -92,11 +92,10 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         if (e.getSource().equals(saveNote)) {
-                            String noteText = noteTextArea.getText();
                             EditNoteState editNoteState = editViewModel.getState();
                             try {
                                 EditNoteView.this.saveNoteController.execute(editNoteState.getNoteTitle(),
-                                                                             noteText,
+                                                                             editNoteState.getNoteText(),
                                                                              editNoteState.getNoteID());
                             } catch (IOException ex) {
                                 throw new RuntimeException(ex);
@@ -128,11 +127,14 @@ public class EditNoteView extends JPanel implements ActionListener, PropertyChan
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         String prompt = JOptionPane.showInputDialog(this, "Enter AI prompt");
-                        String noteText = noteTextArea.getText();
                         EditNoteState editNoteState = editViewModel.getState();
                         if (prompt != null) {
                             try {
-                                createAISnippetController.execute(prompt, noteText, editNoteState);
+                                createAISnippetController.execute(
+                                        prompt,
+                                        editNoteState.getNoteText(),
+                                        editNoteState.getNoteTitle(),
+                                        editNoteState.getNoteID());
                             } catch (IOException ex) {
                                 throw new RuntimeException(ex);
                             }

--- a/src/main/java/view/HomeView.java
+++ b/src/main/java/view/HomeView.java
@@ -65,7 +65,7 @@ public class HomeView extends JPanel implements ActionListener, PropertyChangeLi
                     public void actionPerformed(ActionEvent e) {
                         if (e.getSource().equals(createNote)) {
                             try {
-                                createNoteController.execute("Title Note");
+                                createNoteController.execute("Untitled", "");
                             } catch (IOException ex) {
                                 throw new RuntimeException(ex);
                             }


### PR DESCRIPTION
## Create Note Use Case
- Restructured the create note use case for better clarity and separation of concerns.
- The create note interactor now focuses on initializing a blank edit note state, assigning a unique ID, and setting the EditView on display.
- Responsibility for creating CSV files has been shifted to the save use case.

## Save Note Use Case
- Implemented a more robust approach for persisting Note CSV files, triggered only when the save button is pressed.
- Resolved the issue of new notes unintentionally overriding existing note data by introducing a case for when the note does not already exist by ID.

## EditNoteState Synced with Key Presses
- Enhanced functionality by updating the `noteText` value in `EditNoteState` with each keypress in the `noteTextArea` within `EditView`.
- This improvement eliminates the need to repeatedly call `noteTextArea.getText()` to retrieve the current text.

## Minor Design Changes
- Introduced InputData objects for most use cases, promoting a more organized and maintainable code structure.
- This change addresses issues related to code cleanliness and provides better support for future modifications.
- Conducted general code cleanup for improved readability.